### PR TITLE
Use `read_to_string` to avoid handling UTF-8

### DIFF
--- a/tests/cli/errors.rs
+++ b/tests/cli/errors.rs
@@ -102,8 +102,8 @@ fn deps_file_invalid_utf8() {
         .code(1)
         .stdout("")
         .stderr(format!(
-            "{}/dpnd.txt: This dependency file contains an invalid UTF-8 \
-             sequence after byte 4\n",
+            "Couldn't read the dependency file at '{}/dpnd.txt': stream did \
+             not contain valid UTF-8\n",
             test_proj_dir,
         ));
 }


### PR DESCRIPTION
This branch is being kept as an example of a minor change to reduce error handling code that results in less informative error messages, as shown in `tests/cli/errors.rs`:

            "Couldn't read the dependency file at '{}/dpnd.txt': stream did \
             not contain valid UTF-8\n",

This error message, provided by the error from `fs::read_as_string`, is less informative and will require more effort to debug than the former message:

            "{}/dpnd.txt: This dependency file contains an invalid UTF-8 \
             sequence after byte 4\n",

Of course, the error from `fs::read_as_string` itself likely has enough information to render the details itself, but chooses not to. Even so, the new reference to a "stream", while accurate, introduces extra technical context to the error which is unlikely to help with debugging the issue and more likely to cause confusion for less experienced users.